### PR TITLE
refactor: externalize assets and expand airport resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Aileron Wellness Prototype</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Aileron Wellness</h1>
+    <label for="airport-select">Select Airport</label>
+    <select id="airport-select">
+      <option value="">Choose an airport...</option>
+      <option value="LAX">LAX – Los Angeles</option>
+      <option value="JFK">JFK – New York</option>
+      <option value="LHR">LHR – London Heathrow</option>
+      <option value="DXB">DXB – Dubai International</option>
+      <option value="SYD">SYD – Sydney</option>
+      <option value="NRT">NRT – Tokyo Narita</option>
+    </select>
 
+    <label for="category-select">Support Needed</label>
+    <select id="category-select">
+      <option value="">Choose a support type...</option>
+      <option value="physical">Physical</option>
+      <option value="mental">Mental</option>
+      <option value="social">Social</option>
+    </select>
+
+    <div id="results"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,140 @@
+const data = {
+  LAX: [
+    {
+      category: "physical",
+      name: "Be Relax Spa",
+      description: "Massage and wellness spa in Terminal 1.",
+    },
+    {
+      category: "mental",
+      name: "Interfaith Chapel",
+      description: "Quiet reflection space in Terminal 4.",
+    },
+    {
+      category: "social",
+      name: "Delta Sky Club",
+      description: "Networking lounge for crews in Terminal 3.",
+    },
+  ],
+  JFK: [
+    {
+      category: "physical",
+      name: "Minute Suites",
+      description: "Private sleep suites in Terminal 4.",
+    },
+    {
+      category: "mental",
+      name: "Meditation Room",
+      description: "Calming space near Gate B31 in Terminal 4.",
+    },
+    {
+      category: "social",
+      name: "Wingtips Lounge",
+      description: "Social lounge open to all travelers in Terminal 4.",
+    },
+  ],
+  LHR: [
+    {
+      category: "physical",
+      name: "Revival Lounge Showers",
+      description: "Refreshing showers in Terminal 2 arrivals.",
+    },
+    {
+      category: "mental",
+      name: "Be Relax Spa",
+      description: "Spa treatments in Terminal 3.",
+    },
+    {
+      category: "social",
+      name: "Pilot Bar",
+      description: "Crew-friendly bar in Terminal 4.",
+    },
+  ],
+  DXB: [
+    {
+      category: "physical",
+      name: "Timeless Spa",
+      description: "Full-service spa in Concourse B.",
+    },
+    {
+      category: "mental",
+      name: "Zen Garden",
+      description: "Indoor garden for relaxation in Terminal 3.",
+    },
+    {
+      category: "social",
+      name: "Marhaba Lounge",
+      description: "Friendly meeting space in Terminal 1.",
+    },
+  ],
+  SYD: [
+    {
+      category: "physical",
+      name: "SkyTeam Wellness Spa",
+      description: "Massage and treatments in Terminal 1.",
+    },
+    {
+      category: "mental",
+      name: "Qantas Quiet Zones",
+      description: "Low-stimulation seating in Terminal 1.",
+    },
+    {
+      category: "social",
+      name: "Virgin Australia Lounge",
+      description: "Gather with crews in Terminal 2.",
+    },
+  ],
+  NRT: [
+    {
+      category: "physical",
+      name: "Raffine Massage",
+      description: "Relaxing massage chairs in Terminal 1.",
+    },
+    {
+      category: "mental",
+      name: "Prayer Rooms",
+      description: "Silent rooms for reflection in Terminal 2.",
+    },
+    {
+      category: "social",
+      name: "Narita TraveLounge",
+      description: "Casual meeting space in Terminal 1.",
+    },
+  ],
+};
+
+const airportSelect = document.getElementById("airport-select");
+const categorySelect = document.getElementById("category-select");
+const results = document.getElementById("results");
+
+function render() {
+  const airport = airportSelect.value;
+  const category = categorySelect.value;
+  results.innerHTML = "";
+
+  if (!airport || !category) {
+    return;
+  }
+
+  const resources = data[airport].filter((r) => r.category === category);
+  if (resources.length === 0) {
+    results.innerHTML = "<p>No resources found for this selection.</p>";
+    return;
+  }
+
+  const list = document.createElement("ul");
+  resources.forEach((resource) => {
+    const item = document.createElement("li");
+    const title = document.createElement("h3");
+    title.textContent = resource.name;
+    const desc = document.createElement("p");
+    desc.textContent = resource.description;
+    item.appendChild(title);
+    item.appendChild(desc);
+    list.appendChild(item);
+  });
+  results.appendChild(list);
+}
+
+airportSelect.addEventListener("change", render);
+categorySelect.addEventListener("change", render);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,54 @@
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  background: #f4faff;
+  color: #333;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 700px;
+  margin: 40px auto;
+  background: #ffffff;
+  padding: 30px;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+h1 {
+  font-weight: 300;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+select {
+  width: 100%;
+  padding: 10px;
+  margin: 10px 0;
+  border: 1px solid #cce0ff;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 16px;
+}
+
+#results ul {
+  list-style: none;
+  padding: 0;
+}
+
+#results li {
+  background: #eef5ff;
+  border-radius: 4px;
+  padding: 10px;
+  margin: 10px 0;
+}
+
+#results h3 {
+  margin: 0 0 5px;
+  font-size: 18px;
+}
+
+#results p {
+  margin: 0;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- Separate stylesheet and script into their own files for GitHub Pages
- Expand airport dropdown and add real wellness resources per category
- Keep light, airy styling for easy in-airport reference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce689b96c832f8c01e4250191db6e